### PR TITLE
Enable long text for static page

### DIFF
--- a/database/migrations/2022_09_16_010000_change_page_content_to_medium_text.php
+++ b/database/migrations/2022_09_16_010000_change_page_content_to_medium_text.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Igniter\Pages\Database\Migrations;
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ChangePageContentToMediumText extends Migration
+{
+    public function up()
+    {
+        Schema::table('pages', function (Blueprint $table) {
+            $table->mediumText('content')->change();
+        });
+    }
+
+    public function down()
+    {
+    }
+}

--- a/models/config/pages_model.php
+++ b/models/config/pages_model.php
@@ -134,7 +134,7 @@ $config['form']['fields'] = [
 
 $config['form']['tabs']['fields'] = [
     'content' => [
-        'type' => 'richeditor',
+        'type' => 'codeeditor',
         'tab' => 'lang:igniter.pages::default.text_tab_edit',
         'cssClass' => 'richeditor-fluid',
     ],


### PR DESCRIPTION
The static pages are designed and demoed for pages like "terms & conditions". However, those pages for food ordering sites usually contain a lot of information (though most of them are unnecessary). e.g. there's the one for [Uber eats](https://www.uber.com/legal/bg/document/?country=united-states&lang=en&name=uber-eats-merchant-terms-and-conditions). This change migrates the content field of the page table from text (65,535 chars) to medium text (16,777,215 char). And also change the editor for the content from richtext to codeediter because the richtext editor dies when there are more than ~10k chars.